### PR TITLE
Fix spawn selection bug and Build CI never running on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master ]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Players could set their spawn more than once because the duplicate-spawn check looked up the player by name in a map keyed by UUID, so the check never matched. The check now uses the player's UUID, consistent with how spawns are stored.
+- The `Build` CI workflow only ran on pushes/PRs targeting `main`/`develop`, but the repository's default branch is `master`, so it never ran. It now targets `master`.
 
 ## [1.2] – (date unknown)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Players could set their spawn more than once because the duplicate-spawn check looked up the player by name in a map keyed by UUID, so the check never matched. The check now uses the player's UUID, consistent with how spawns are stored.
+
 ## [1.2] – (date unknown)
 
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
     <properties>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+        <mockito.version>4.11.0</mockito.version>
     </properties>
 
     <build>
@@ -26,6 +28,11 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -69,6 +76,18 @@
             <artifactId>spigot-api</artifactId>
             <version>1.15.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/dansplugins/spawnsystem/data/PersistentData.java
+++ b/src/main/java/dansplugins/spawnsystem/data/PersistentData.java
@@ -26,7 +26,7 @@ public class PersistentData {
         Location spawnLocation = new Location(world, x, y, z);
 
         // set spawn
-        if (!getPlayerSpawns().containsKey(player.getName())) {
+        if (!getPlayerSpawns().containsKey(player.getUniqueId())) {
             getPlayerSpawns().put(player.getUniqueId(), spawnLocation);
             getPlayersWithSpawns().add(player.getUniqueId());
         }

--- a/src/test/java/dansplugins/spawnsystem/data/PersistentDataTest.java
+++ b/src/test/java/dansplugins/spawnsystem/data/PersistentDataTest.java
@@ -1,0 +1,33 @@
+package dansplugins.spawnsystem.data;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PersistentDataTest {
+
+    @Test
+    void setPlayersSpawn_secondCallForSamePlayer_doesNotOverwriteSpawn() {
+        PersistentData persistentData = new PersistentData();
+        UUID playerId = UUID.randomUUID();
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(playerId);
+        when(player.getName()).thenReturn("SomePlayer");
+        World world = mock(World.class);
+
+        persistentData.setPlayersSpawn(player, world, 1, 2, 3);
+        persistentData.setPlayersSpawn(player, world, 100, 200, 300);
+
+        Location storedSpawn = persistentData.getPlayerSpawns().get(playerId);
+        assertEquals(1, storedSpawn.getBlockX());
+        assertEquals(2, storedSpawn.getBlockY());
+        assertEquals(3, storedSpawn.getBlockZ());
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes the spawn-selection duplicate check in `PersistentData.setPlayersSpawn`, which looked up the player by name (`player.getName()`) in a `HashMap<UUID, Location>`. Since the map is keyed by UUID, `containsKey()` could never match, so the "already set your spawn" guard never triggered and players could reset their spawn indefinitely. The check now uses `player.getUniqueId()`, consistent with how spawns are stored and removed elsewhere in the class.
- Adds JUnit 5 + Mockito as test dependencies (the project had no test framework or `src/test` directory previously) and a regression test covering the fix.
- Fixes the `Build` GitHub Actions workflow, which only triggered on push/PR events targeting `main`/`develop`. This repository's default branch is `master` and no `develop` branch exists, so the workflow has never actually run on a pull request. Retargeted at `master`.
- Documents both fixes in `CHANGELOG.md` under `[Unreleased]`.

## Context
There was an existing open PR (#61) from the Copilot coding agent for the same bug (#41), with the identical one-line fix. However, that PR's branch has an entirely unrelated git history (no common ancestor with current `master` — 91 commits reconstructing the whole plugin from an old/rewritten history), so it can't be cleanly rebased or merged without a same-content, disjoint-history merge. This PR reapplies the same fix cleanly on top of current `master`, with a regression test added; closing #61 as superseded.

## Test plan
- [x] `mvn compile` — success
- [x] `mvn test` — new regression test passes
- [x] Empirically verified regression coverage: stashed the one-line fix, confirmed `PersistentDataTest` **fails** (`expected: <1> but was: <100>`), restored the fix, confirmed it **passes**
- [x] Checked `COMMANDS.md` / `USER_GUIDE.md` / `CONFIG.md` — no command, permission, or config surface changed, so no updates needed there

Closes #41

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
