### PR TITLE
Add unit tests for BlockChecker and PersistentData.resetSpawn

### DIFF
--- a/src/test/java/dansplugins/spawnsystem/data/PersistentDataTest.java
+++ b/src/test/java/dansplugins/spawnsystem/data/PersistentDataTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.Test;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,5 +32,30 @@ class PersistentDataTest {
         assertEquals(1, storedSpawn.getBlockX());
         assertEquals(2, storedSpawn.getBlockY());
         assertEquals(3, storedSpawn.getBlockZ());
+    }
+
+    @Test
+    void resetSpawn_playerWithSpawnSet_removesSpawnAndPlayerFromTrackedList() {
+        PersistentData persistentData = new PersistentData();
+        UUID playerId = UUID.randomUUID();
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(playerId);
+        World world = mock(World.class);
+        persistentData.setPlayersSpawn(player, world, 1, 2, 3);
+
+        persistentData.resetSpawn(playerId);
+
+        assertNull(persistentData.getPlayerSpawns().get(playerId));
+        assertFalse(persistentData.getPlayersWithSpawns().contains(playerId));
+    }
+
+    @Test
+    void resetSpawn_playerWithoutSpawnSet_doesNotThrow() {
+        PersistentData persistentData = new PersistentData();
+        UUID playerId = UUID.randomUUID();
+
+        persistentData.resetSpawn(playerId);
+
+        assertTrue(persistentData.getPlayersWithSpawns().isEmpty());
     }
 }

--- a/src/test/java/dansplugins/spawnsystem/utils/BlockCheckerTest.java
+++ b/src/test/java/dansplugins/spawnsystem/utils/BlockCheckerTest.java
@@ -1,0 +1,41 @@
+package dansplugins.spawnsystem.utils;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BlockCheckerTest {
+
+    private final BlockChecker blockChecker = new BlockChecker();
+
+    @ParameterizedTest
+    @EnumSource(value = Material.class, names = {
+            "ACACIA_SIGN", "ACACIA_WALL_SIGN",
+            "BIRCH_SIGN", "BIRCH_WALL_SIGN",
+            "DARK_OAK_SIGN", "DARK_OAK_WALL_SIGN",
+            "JUNGLE_SIGN", "JUNGLE_WALL_SIGN",
+            "OAK_SIGN", "OAK_WALL_SIGN",
+            "SPRUCE_SIGN", "SPRUCE_WALL_SIGN"
+    })
+    void isSign_signMaterial_returnsTrue(Material material) {
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(material);
+
+        assertTrue(blockChecker.isSign(block));
+    }
+
+    @Test
+    void isSign_nonSignMaterial_returnsFalse() {
+        Block block = mock(Block.class);
+        when(block.getType()).thenReturn(Material.STONE);
+
+        assertFalse(blockChecker.isSign(block));
+    }
+}


### PR DESCRIPTION
## Summary

- Test coverage was expanded for two previously untested behavior-bearing units.
- `BlockChecker.isSign` is now exercised against every sign `Material` variant it recognizes (parameterized), plus a non-sign material, confirming current classification behavior is locked in.
- `PersistentData.resetSpawn` is now covered for both the case where a spawn was previously set (removal from both the spawn map and the tracked-player list is verified) and the case where no spawn was set (no exception is thrown).
- No production code was changed. This PR is characterization-only, per the repo's Stage B (unit-test expansion) work mode; the open-issue backlog was empty at triage time, so this cycle's work was selected accordingly.

## Test plan

- [x] `mvn compile` — build succeeds
- [x] `mvn test` — 16/16 tests pass (13 new `BlockCheckerTest` cases, 2 new `PersistentDataTest` cases, 1 pre-existing test)

No `Closes #N` — no open issues existed at triage time for this repo; this PR was selected as an alternative cycle work mode (unit-test expansion) per the dev-loop skill.

---
This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->