### PR TITLE
chore: release version 2.0.0-SNAPSHOT-8-8-2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [2.0.0-SNAPSHOT-8-8-2026] – 2026-08-08
+
+### Changed
+- Dans-Spawn-System is now developed AI-first. Day-to-day feature work, grooming, review and maintenance run through AI agents working directly against this repository, with the maintainers setting direction and approving what lands. The major version bump marks that change in how the project is built — it is not a break in behaviour, configuration or stored data, and existing installations can upgrade in place. Released as `2.0.0-SNAPSHOT-8-8-2026`: the AI-first line has not yet been verified in live operation, and the dated snapshot designation stays until it has.
 
 ### Fixed
 - Players could set their spawn more than once because the duplicate-spawn check looked up the player by name in a map keyed by UUID, so the check never matched. The check now uses the player's UUID, consistent with how spawns are stored.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>KingdomProgrammers</groupId>
     <artifactId>Dans-Spawn-System</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT-8-8-2026</version>
     <packaging>jar</packaging>
 
     <name>Dan's Spawn System</name>


### PR DESCRIPTION
## Summary

The version has been bumped from `1.2-SNAPSHOT` to `2.0.0-SNAPSHOT-8-8-2026` in `pom.xml`.

The bump marks Dans-Spawn-System moving to an AI-first development approach: day-to-day feature work,
grooming, review and maintenance now run through AI agents working directly against this
repository, with the maintainers setting direction and approving what lands.

It is not a compatibility break. Behaviour, configuration and stored data are unchanged, and
existing installations can upgrade in place — the version marks a change in how the project is
built, not in what it does.

## Snapshot designation

The dated snapshot designation follows the precedent set by Medieval Factions'
`6.0.0-SNAPSHOT-7-25-2026`: the AI-first line has not yet been verified in live operation, and
the designation stays until it has.

## Notes

This is part of a garden-wide pass applying the same bump across every project tended by
Gardener. Only version metadata has been changed; no functional code was touched.

---
*Drafted by Claude on behalf of Daniel Stephenson.*
