### PR TITLE
Fix misleading and missing feedback from /resetspawn

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ making any changes.
 - Language: Java
 - Build tool: Maven
 - Target platform: Spigot / Paper (Minecraft plugin, API version 1.13+)
-- Test framework: Not yet configured (add JUnit via Maven Surefire in pom.xml when introducing tests)
+- Test framework: JUnit 5 with Mockito, run via Maven Surefire (`mvn test`)
 
 ## Project Structure
 
@@ -21,7 +21,7 @@ making any changes.
   - `data/` – Persistent data model
   - `bstats/` – bStats metrics integration
 - `src/main/resources/` – `plugin.yml` and other resources
-- `src/test/java/` – Unit tests (if/when a test suite is added)
+- `src/test/java/` – Unit tests, mirroring the main source package layout
 
 ## Coding Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+- `/resetspawn <player>` reported a green success message even when the supplied name matched no known player, so an operator was told a reset had happened when nothing was changed. An unresolvable name is now reported as such and no reset is claimed.
+- `/resetspawn` produced no output at all when run from the console, a command block, or RCON. Non-player senders are now told that the command is for in-game players only.
+- A player targeted by `/resetspawn <player>` while offline no longer causes a swallowed `NullPointerException`; the target is looked up by UUID and notified only when actually online.
+
+### Changed
+- `ResetSpawnCommand` now depends on `org.bukkit.Server` rather than on the plugin instance, which allows its behaviour to be unit tested.
+
+### Added
+- Unit tests for `ResetSpawnCommand` covering permission handling, unresolvable names, offline and online targets, and non-player senders.
+
 ## [2.0.0-SNAPSHOT-8-8-2026] – 2026-08-08
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,9 @@ Issues are grouped into [milestones](https://github.com/Dans-Plugins/Dans-Spawn-
 
 ## Testing
 
-There are currently no automated unit tests configured for this project.
+This project has a JUnit 5 unit test suite (with Mockito for Bukkit collaborators) under `src/test/java/`. Run it with `mvn test`, and please add or update tests alongside any change that can be exercised without a running server.
 
-Please verify your changes manually by:
+The suite cannot cover everything, so please also verify your changes manually by:
 
 - Building the plugin: `mvn clean package`
 - Copying the built JAR from `target/` into your test server's `plugins/` folder

--- a/README.md
+++ b/README.md
@@ -43,19 +43,19 @@ Please fill out a bug report [here](https://github.com/Dans-Plugins/Dans-Spawn-S
 
 ### Automated Tests
 
-This project does not currently include automated unit tests.
-
-To verify that the project builds successfully, run:
+This project has a JUnit 5 unit test suite (with Mockito for Bukkit collaborators) under `src/test/java/`. To run it:
 
 Linux:
 
-    mvn clean package
+    mvn test
 
 Windows:
 
-    mvn.cmd clean package
+    mvn.cmd test
 
-If you see `BUILD SUCCESS`, the project compiled successfully. For validating functional changes, follow the steps in the **Development** section below to run the plugin on a test server.
+To run the tests and build the plugin jar in one step, use `mvn clean package` instead — the tests run as part of that build.
+
+If you see `BUILD SUCCESS`, the project compiled and the tests passed. The suite covers logic that can be exercised without a running server; for anything that needs a live Bukkit runtime (event listeners, world interaction, on-disk persistence), follow the steps in the **Development** section below to validate on a test server.
 
 ## Development
 

--- a/src/main/java/dansplugins/spawnsystem/commands/ResetSpawnCommand.java
+++ b/src/main/java/dansplugins/spawnsystem/commands/ResetSpawnCommand.java
@@ -1,56 +1,71 @@
 package dansplugins.spawnsystem.commands;
 
-import dansplugins.spawnsystem.DansSpawnSystem;
 import dansplugins.spawnsystem.data.PersistentData;
 import dansplugins.spawnsystem.utils.UUIDChecker;
 import org.bukkit.ChatColor;
+import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import java.util.UUID;
 
 public class ResetSpawnCommand {
     private final PersistentData persistentData;
     private final UUIDChecker uuidChecker;
-    private final DansSpawnSystem dansSpawnSystem;
+    private final Server server;
 
-    public ResetSpawnCommand(PersistentData persistentData, UUIDChecker uuidChecker, DansSpawnSystem dansSpawnSystem) {
+    public ResetSpawnCommand(PersistentData persistentData, UUIDChecker uuidChecker, Server server) {
         this.persistentData = persistentData;
         this.uuidChecker = uuidChecker;
-        this.dansSpawnSystem = dansSpawnSystem;
+        this.server = server;
     }
 
     public void execute(CommandSender sender, String[] args) {
-        // if sender instanceof player
-        if (sender instanceof Player) {
-            Player player = (Player) sender;
-
-            if (args.length > 0) {
-                if (player.hasPermission("spawnsystem.reset.others") || player.hasPermission("spawnsystem.admin")) {
-                    // reset a specific player's spawn
-                    String targetPlayer = args[0];
-                    persistentData.resetSpawn(uuidChecker.findUUIDBasedOnPlayerName(targetPlayer));
-                    player.sendMessage(ChatColor.GREEN + "Spawn reset for " + targetPlayer + "!");
-                    try {
-                        dansSpawnSystem.getServer().getPlayer(targetPlayer).sendMessage(ChatColor.GREEN + "Your spawn has been reset!");
-                    } catch(Exception e) {
-
-                    }
-                }
-                else {
-                    player.sendMessage(ChatColor.RED + "Sorry! In order to use this command, you need the following permission: 'spawnsystem.reset.others'");
-                }
-
-            }
-            else {
-                if (player.hasPermission("spawnsystem.reset.self") || player.hasPermission("spawnsystem.admin")) {
-                    // reset the spawn of the command sender
-                    persistentData.resetSpawn(uuidChecker.findUUIDBasedOnPlayerName(player.getName()));
-                    player.sendMessage(ChatColor.GREEN + "You have reset your spawn!");
-                }
-                else {
-                    player.sendMessage(ChatColor.RED + "Sorry! In order to use this command, you need the following permission: 'spawnsystem.reset.self'");
-                }
-            }
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Sorry! This command can only be used by an in-game player.");
+            return;
         }
+
+        Player player = (Player) sender;
+
+        if (args.length > 0) {
+            resetSpawnOfOtherPlayer(player, args[0]);
+        }
+        else {
+            resetSpawnOfSender(player);
+        }
+    }
+
+    private void resetSpawnOfOtherPlayer(Player player, String targetPlayerName) {
+        if (!player.hasPermission("spawnsystem.reset.others") && !player.hasPermission("spawnsystem.admin")) {
+            player.sendMessage(ChatColor.RED + "Sorry! In order to use this command, you need the following permission: 'spawnsystem.reset.others'");
+            return;
+        }
+
+        UUID targetPlayerUUID = uuidChecker.findUUIDBasedOnPlayerName(targetPlayerName);
+        if (targetPlayerUUID == null) {
+            player.sendMessage(ChatColor.RED + "Sorry! A player named '" + targetPlayerName + "' could not be found.");
+            return;
+        }
+
+        persistentData.resetSpawn(targetPlayerUUID);
+        player.sendMessage(ChatColor.GREEN + "Spawn reset for " + targetPlayerName + "!");
+
+        // the target is only notified when they happen to be online
+        Player targetPlayer = server.getPlayer(targetPlayerUUID);
+        if (targetPlayer != null) {
+            targetPlayer.sendMessage(ChatColor.GREEN + "Your spawn has been reset!");
+        }
+    }
+
+    private void resetSpawnOfSender(Player player) {
+        if (!player.hasPermission("spawnsystem.reset.self") && !player.hasPermission("spawnsystem.admin")) {
+            player.sendMessage(ChatColor.RED + "Sorry! In order to use this command, you need the following permission: 'spawnsystem.reset.self'");
+            return;
+        }
+
+        persistentData.resetSpawn(player.getUniqueId());
+        player.sendMessage(ChatColor.GREEN + "You have reset your spawn!");
     }
 
 }

--- a/src/main/java/dansplugins/spawnsystem/services/CommandService.java
+++ b/src/main/java/dansplugins/spawnsystem/services/CommandService.java
@@ -20,7 +20,7 @@ public class CommandService {
     public boolean interpretCommand(CommandSender sender, String label, String[] args) {
 
         if (label.equalsIgnoreCase("resetspawn")) {
-            ResetSpawnCommand command = new ResetSpawnCommand(persistentData, uuidChecker, dansSpawnSystem);
+            ResetSpawnCommand command = new ResetSpawnCommand(persistentData, uuidChecker, dansSpawnSystem.getServer());
             command.execute(sender, args);
             return true;
         }

--- a/src/test/java/dansplugins/spawnsystem/commands/ResetSpawnCommandTest.java
+++ b/src/test/java/dansplugins/spawnsystem/commands/ResetSpawnCommandTest.java
@@ -1,0 +1,126 @@
+package dansplugins.spawnsystem.commands;
+
+import dansplugins.spawnsystem.data.PersistentData;
+import dansplugins.spawnsystem.utils.UUIDChecker;
+import org.bukkit.ChatColor;
+import org.bukkit.Server;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class ResetSpawnCommandTest {
+
+    private final PersistentData persistentData = mock(PersistentData.class);
+    private final UUIDChecker uuidChecker = mock(UUIDChecker.class);
+    private final Server server = mock(Server.class);
+    private final ResetSpawnCommand resetSpawnCommand = new ResetSpawnCommand(persistentData, uuidChecker, server);
+
+    @Test
+    void execute_nonPlayerSender_isToldTheCommandIsPlayerOnly() {
+        CommandSender console = mock(CommandSender.class);
+
+        resetSpawnCommand.execute(console, new String[]{});
+
+        verify(console).sendMessage(ChatColor.RED + "Sorry! This command can only be used by an in-game player.");
+        verifyNoInteractions(persistentData);
+    }
+
+    @Test
+    void execute_unresolvableTargetName_reportsNotFoundAndResetsNothing() {
+        Player player = playerWithPermission("spawnsystem.reset.others");
+        when(uuidChecker.findUUIDBasedOnPlayerName("Ghost")).thenReturn(null);
+
+        resetSpawnCommand.execute(player, new String[]{"Ghost"});
+
+        verify(player).sendMessage(ChatColor.RED + "Sorry! A player named 'Ghost' could not be found.");
+        verify(player, never()).sendMessage(startsWith(ChatColor.GREEN + "Spawn reset for"));
+        verifyNoInteractions(persistentData);
+    }
+
+    @Test
+    void execute_offlineTargetName_resetsSpawnAndConfirmsToSender() {
+        Player player = playerWithPermission("spawnsystem.reset.others");
+        UUID targetId = UUID.randomUUID();
+        when(uuidChecker.findUUIDBasedOnPlayerName("Steve")).thenReturn(targetId);
+        when(server.getPlayer(targetId)).thenReturn(null);
+
+        resetSpawnCommand.execute(player, new String[]{"Steve"});
+
+        verify(persistentData).resetSpawn(targetId);
+        verify(player).sendMessage(ChatColor.GREEN + "Spawn reset for Steve!");
+    }
+
+    @Test
+    void execute_onlineTargetName_alsoNotifiesTheTarget() {
+        Player player = playerWithPermission("spawnsystem.reset.others");
+        UUID targetId = UUID.randomUUID();
+        Player target = mock(Player.class);
+        when(uuidChecker.findUUIDBasedOnPlayerName("Steve")).thenReturn(targetId);
+        when(server.getPlayer(targetId)).thenReturn(target);
+
+        resetSpawnCommand.execute(player, new String[]{"Steve"});
+
+        verify(persistentData).resetSpawn(targetId);
+        verify(target).sendMessage(ChatColor.GREEN + "Your spawn has been reset!");
+    }
+
+    @Test
+    void execute_targetNameWithoutOthersPermission_isRefused() {
+        Player player = playerWithPermission("spawnsystem.reset.self");
+
+        resetSpawnCommand.execute(player, new String[]{"Steve"});
+
+        verify(player).sendMessage(contains("spawnsystem.reset.others"));
+        verifyNoInteractions(persistentData);
+        verifyNoInteractions(uuidChecker);
+    }
+
+    @Test
+    void execute_noArguments_resetsTheSendersOwnSpawn() {
+        Player player = playerWithPermission("spawnsystem.reset.self");
+        UUID playerId = UUID.randomUUID();
+        when(player.getUniqueId()).thenReturn(playerId);
+
+        resetSpawnCommand.execute(player, new String[]{});
+
+        verify(persistentData).resetSpawn(playerId);
+        verify(player).sendMessage(ChatColor.GREEN + "You have reset your spawn!");
+    }
+
+    @Test
+    void execute_noArgumentsWithoutSelfPermission_isRefused() {
+        Player player = playerWithPermission("spawnsystem.reset.others");
+
+        resetSpawnCommand.execute(player, new String[]{});
+
+        verify(player).sendMessage(contains("spawnsystem.reset.self"));
+        verifyNoInteractions(persistentData);
+    }
+
+    @Test
+    void execute_adminPermission_resetsAnotherPlayersSpawn() {
+        Player player = playerWithPermission("spawnsystem.admin");
+        UUID targetId = UUID.randomUUID();
+        when(uuidChecker.findUUIDBasedOnPlayerName("Steve")).thenReturn(targetId);
+
+        resetSpawnCommand.execute(player, new String[]{"Steve"});
+
+        verify(persistentData).resetSpawn(targetId);
+    }
+
+    private Player playerWithPermission(String permission) {
+        Player player = mock(Player.class);
+        when(player.hasPermission(permission)).thenReturn(true);
+        return player;
+    }
+}


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

Three defects in `/resetspawn` sender feedback are fixed, and the documentation claim that this project has no automated tests is corrected.

- **Misleading success (#67).** `/resetspawn <player>` sent a green "Spawn reset for X!" unconditionally. `UUIDChecker.findUUIDBasedOnPlayerName` returns `null` for an unknown name, and `PersistentData.resetSpawn(null)` is a no-op, so an operator was told a reset had happened when nothing changed. An unresolvable name is now reported as not found and no reset is claimed.
- **Silent no-op from the console (#68).** `execute` wrapped its whole body in `if (sender instanceof Player)` with no `else`, while `CommandService.interpretCommand` still returned `true`, so Bukkit suppressed its own fallback message too. A non-player sender received nothing at all. Such senders are now told the command is for in-game players only, which is what `COMMANDS.md` already documented.
- **Swallowed exception.** The target notification was wrapped in a `try` whose `catch (Exception e)` block was empty, absorbing the `NullPointerException` thrown when `getPlayer(<name>)` returned `null` for an offline target. The target is now looked up by UUID and null-checked, so the offline case is expressed rather than caught.
- **Documentation drift (#69).** `README.md`, `CONTRIBUTING.md`, and `.github/copilot-instructions.md` each stated that no test suite exists. JUnit 5 and Mockito are configured in `pom.xml` and 24 tests now run under `mvn test`. All three files are corrected, and the manual server-verification steps are kept as the complement for behaviour needing a live Bukkit runtime.

## Supporting change

`ResetSpawnCommand` now takes an `org.bukkit.Server` instead of the plugin instance, and `CommandService` passes `dansSpawnSystem.getServer()`. This is what makes the command testable at all: `DansSpawnSystem` is `final` and `JavaPlugin.getServer()` is `final`, neither of which Mockito's default (subclass) mock maker can stub, whereas `Server` is an interface. No caller outside `CommandService` constructs this class.

The self-reset path also now uses `player.getUniqueId()` directly instead of round-tripping the sender's own name through `UUIDChecker`. Behaviour is identical for an online sender — the checker scans online players first and matches by name — but the same null-returning failure mode is removed from that path.

## Test plan

- [x] `mvn test` — 24 tests pass (8 new in `ResetSpawnCommandTest`, 16 pre-existing).
- [x] Regression evidence confirmed empirically, not by reasoning: with the previous command body restored (the `Server` parameter kept so the tests still compile), `mvn test` reports 4 failures — `execute_nonPlayerSender_isToldTheCommandIsPlayerOnly`, `execute_unresolvableTargetName_reportsNotFoundAndResetsNothing`, `execute_onlineTargetName_alsoNotifiesTheTarget`, and `execute_noArguments_resetsTheSendersOwnSpawn`. All pass again once the fix is restored.
- [ ] Manual server check recommended before release: run `/resetspawn` from the server console (expect the player-only message), `/resetspawn NoSuchPlayer` in game (expect not-found, no success), and `/resetspawn <online player>` (expect both messages). Event-driven and on-disk behaviour is out of reach of the unit suite.

## Documentation

`COMMANDS.md` and `USER_GUIDE.md` were re-checked against the implementation and need no change — the documented syntax, permission nodes, and the "in-game players only" note all still match, and the permission strings match `plugin.yml`. `CONFIG.md` is unaffected. `CHANGELOG.md` gains an `[Unreleased]` section describing this change.

## Deferred this cycle

The remaining open issues were filed during this cycle's triage and are intentionally left for a later one:

- **#70** (`develop` branch referenced in contributor docs) — the branch-workflow lines are a project policy statement rather than a factual error, so a maintainer decision on the intended target branch is wanted before they are rewritten. The purely factual test-framework line in the same file is corrected here under #69.
- **#71** (spawns with a zero coordinate discarded on load) — the fix requires extracting the record parsing in `StorageService` from its file and world-creation concerns before it can be tested, which exceeds a polish-sized change.
- **#72** (sign types newer than Minecraft 1.15 unrecognised) — blocked on a `spigot-api` version bump or a deliberate move away from the enum switch, both of which change the supported server range and belong to the maintainers.

Closes #67
Closes #68
Closes #69

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_
